### PR TITLE
Support using custom/arbitrary Curio slots through configuration.

### DIFF
--- a/src/main/kotlin/com/possible_triangle/create_jetpack/config/ServerConfig.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/config/ServerConfig.kt
@@ -14,7 +14,9 @@ interface IServerConfig {
     val hoverSpeed: Double
     val swimModifier: Double
     val elytraBoostEnabled: Boolean
+    //val curioSlots: List<String>
     fun isAllowed(ench: Enchantment): Boolean
+    fun isCurioSlotAllowed(slot: String): Boolean
 }
 
 data class SyncedConfig(
@@ -26,8 +28,10 @@ data class SyncedConfig(
     override val hoverSpeed: Double,
     override val swimModifier: Double,
     override val elytraBoostEnabled: Boolean,
+    //override val curioSlots: List<String>
 ) : IServerConfig {
     override fun isAllowed(ench: Enchantment) = true
+    override fun isCurioSlotAllowed(slot: String) = true
 }
 
 class ServerConfig(builder: ForgeConfigSpec.Builder) : IServerConfig {
@@ -63,5 +67,11 @@ class ServerConfig(builder: ForgeConfigSpec.Builder) : IServerConfig {
         val key = ForgeRegistries.ENCHANTMENTS.getKey(ench) ?: return true
         val contained = enchantmentsList.get().map(::ResourceLocation).any { key == it }
         return contained != enchantmentsIsBlacklist.get()
+    }
+
+    private val curiosSlotList = builder.defineList("compat.curios.slots.list", listOf<String>("back")) { true }
+    //override val curioSlots get() = curiosSlotList.get()!!
+    override fun isCurioSlotAllowed(slot: String): Boolean {
+        return curiosSlotList.get().any { slot == it }
     }
 }

--- a/src/main/kotlin/com/possible_triangle/create_jetpack/config/SyncConfigMessage.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/config/SyncConfigMessage.kt
@@ -20,6 +20,7 @@ class SyncConfigMessage (private val config: IServerConfig) {
                 hoverSpeed = buf.readDouble(),
                 swimModifier = buf.readDouble(),
                 elytraBoostEnabled = buf.readBoolean(),
+                //curioSlots = buf.readList(),
             )
             return SyncConfigMessage(config)
         }
@@ -34,6 +35,7 @@ class SyncConfigMessage (private val config: IServerConfig) {
         buf.writeDouble(config.hoverSpeed)
         buf.writeDouble(config.swimModifier)
         buf.writeBoolean(config.elytraBoostEnabled)
+        //buf.writeList(config.curioSlots)
     }
 
     fun handle(context: Supplier<Context>) {

--- a/src/main/kotlin/com/possible_triangle/create_jetpack/item/BrassJetpack.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/item/BrassJetpack.kt
@@ -84,7 +84,7 @@ class BrassJetpack(properties: Properties, blockItem: ItemEntry<BacktankBlockIte
     override fun isValid(context: Context): Boolean {
         return when (val source = context.source) {
             is EquipmentSource -> source.slot == EquipmentSlot.CHEST
-            is CuriosSource -> source.slot == "back"
+            is CuriosSource -> Configs.SERVER.isCurioSlotAllowed(source.slot)
             else -> false
         }
     }


### PR DESCRIPTION
This is my first time working in Kotlin instead of Java, so I'm not entirely sure that I implemented this correctly. I also wasn't able to test it in-game as some of the Gradle dependencies require authentication. However, it *seems* sane to me and trying to execute `runClient` didn't complain about any of my changes before crashing due to the missing dependencies.