### PR TITLE
Added keybind menu title

### DIFF
--- a/src/main/resources/assets/create_jetpack/lang/de_de.json
+++ b/src/main/resources/assets/create_jetpack/lang/de_de.json
@@ -24,5 +24,6 @@
   "item.create_jetpack.netherite_jetpack.tooltip.control3": "Drücke [G]",
   "item.create_jetpack.netherite_jetpack.tooltip.control4": "Press [H]",
   "item.create_jetpack.netherite_jetpack.tooltip.summary": "Ermöglicht Fliegen mithilfe komprimierter Luft",
-  "item.create_jetpack.netherite_jetpack_placeable": "Platzierbares Netheritjetpack"
+  "item.create_jetpack.netherite_jetpack_placeable": "Platzierbares Netheritjetpack",
+  "key.categories.movement.jetpack": "Create Jetpack"
 }

--- a/src/main/resources/assets/create_jetpack/lang/es_es.json
+++ b/src/main/resources/assets/create_jetpack/lang/es_es.json
@@ -9,5 +9,6 @@
   "item.create_jetpack.jetpack.tooltip.control3": "Presiona [G]",
   "item.create_jetpack.jetpack.tooltip.action3": "Encender/apagar el motor",
   "item.create_jetpack.jetpack.tooltip.control4": "Presiona [H]",
-  "item.create_jetpack.jetpack.tooltip.action4": "Activar/desactivar el modo flotante"
+  "item.create_jetpack.jetpack.tooltip.action4": "Activar/desactivar el modo flotante",
+  "key.categories.movement.jetpack": "Create Jetpack"
 }

--- a/src/main/resources/assets/create_jetpack/lang/ja_jp.json
+++ b/src/main/resources/assets/create_jetpack/lang/ja_jp.json
@@ -9,5 +9,6 @@
   "item.create_jetpack.jetpack.tooltip.control3": "Gを押して",
   "item.create_jetpack.jetpack.tooltip.action3": "エンジンのオン/オフを切り替え",
   "item.create_jetpack.jetpack.tooltip.control4": "Hで",
-  "item.create_jetpack.jetpack.tooltip.action4": "ホバーモードのオン/オフを切り替え"
+  "item.create_jetpack.jetpack.tooltip.action4": "ホバーモードのオン/オフを切り替え",
+  "key.categories.movement.jetpack": "Create ジェットパック"
 }

--- a/src/main/resources/assets/create_jetpack/lang/ko_kr.json
+++ b/src/main/resources/assets/create_jetpack/lang/ko_kr.json
@@ -24,5 +24,6 @@
   "item.create_jetpack.netherite_jetpack.tooltip.control3": "[G]를 눌러서",
   "item.create_jetpack.netherite_jetpack.tooltip.control4": "[H]를 눌러서",
   "item.create_jetpack.netherite_jetpack.tooltip.summary": "가압된 공기를 사용하여 비행 기능을 제공합니다",
-  "item.create_jetpack.netherite_jetpack_placeable": "네더라이트 제트팩"
+  "item.create_jetpack.netherite_jetpack_placeable": "네더라이트 제트팩",
+  "key.categories.movement.jetpack": "Create 제트팩"
 }

--- a/src/main/resources/assets/create_jetpack/lang/ru_ru.json
+++ b/src/main/resources/assets/create_jetpack/lang/ru_ru.json
@@ -25,5 +25,5 @@
   "item.create_jetpack.netherite_jetpack.tooltip.control4": "Нажмите [H]",
   "item.create_jetpack.netherite_jetpack.tooltip.summary": "Позволяет летать с помощью сжатого воздуха.",
   "item.create_jetpack.netherite_jetpack_placeable": "Размещаемый незеритовый реактивный ранец",
-  "key.categories.movement.jetpack": "Create: Jetpack"
+  "key.categories.movement.jetpack": "Create Jetpack"
 }

--- a/src/main/resources/assets/create_jetpack/lang/zh_cn.json
+++ b/src/main/resources/assets/create_jetpack/lang/zh_cn.json
@@ -9,5 +9,6 @@
   "item.create_jetpack.jetpack.tooltip.control3": "按下 [G]",
   "item.create_jetpack.jetpack.tooltip.action3": "开启/关闭引擎",
   "item.create_jetpack.jetpack.tooltip.control4": "按下 [H]",
-  "item.create_jetpack.jetpack.tooltip.action4": "开启/关闭悬浮模式"
+  "item.create_jetpack.jetpack.tooltip.action4": "开启/关闭悬浮模式",
+  "key.categories.movement.jetpack": "欢迎来到机械动力 喷气背包"
 }


### PR DESCRIPTION
Currently, the keybind menu title is undefined. I propose to add the entry in the language files. For now, I just took your default branch as a reference, but we could adjust all your versions. I used the reference "Create" translation for the Create mod language files and "Jetpack" translation from your mod, to ensure consistency.

Old:

![image](https://github.com/user-attachments/assets/06114d35-5705-458f-824b-da45c9a598a1)

New:

![image](https://github.com/user-attachments/assets/83572fcf-243a-499d-b549-c7a73c775f44)

See also: https://github.com/kkempfer/Create-Survive-Explore/issues/94