### PR TITLE
hopefully fix #132

### DIFF
--- a/src/main/kotlin/com/possible_triangle/create_jetpack/Content.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/Content.kt
@@ -126,11 +126,15 @@ object Content {
                             LootItem.lootTableItem(getItem())
                                 .apply(
                                     CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY)
-                                        .copy("Air", "Air")
+                                        .copy("VanillaTag", "{}", CopyNbtFunction.MergeStrategy.MERGE)
                                 )
                                 .apply(
                                     CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY)
-                                        .copy("VanillaTag", "{}", CopyNbtFunction.MergeStrategy.MERGE)
+                                        .copy("VanillaTag.Air", "Air")
+                                )
+                                .apply(
+                                    CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY)
+                                        .copy("Air", "Air")
                                 )
                         )
                 )


### PR DESCRIPTION
this would theoretically probably fix an issue where it doesn't properly drop its filled self, the only way to break it filled seems to have been to have it already filled or to use a custom mechanic to break and equip it when right clicked with an empty hand and no back armor on.