### PR TITLE
Fix #191: prevent crash on join caused by client config access

### DIFF
--- a/src/main/kotlin/com/possible_triangle/create_jetpack/config/ClientConfig.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/config/ClientConfig.kt
@@ -23,6 +23,6 @@ class ClientConfig(builder: ModConfigSpec.Builder) {
     private val SEASONAL_EFFECTS = builder.define("effects.seasonal", true)
 
     val spawnSnowParticles
-        get() = isChristmas && SEASONAL_EFFECTS.get()
+        get() = isChristmas && runCatching { SEASONAL_EFFECTS.get() }.getOrDefault(true)
 
 }

--- a/src/main/kotlin/com/possible_triangle/create_jetpack/item/JetpackItem.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/item/JetpackItem.kt
@@ -21,6 +21,7 @@ import net.minecraft.world.item.ArmorMaterial
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.enchantment.Enchantment
 import net.minecraft.world.phys.Vec3
+import net.neoforged.fml.loading.FMLEnvironment
 import java.util.*
 
 open class JetpackItem(
@@ -103,12 +104,12 @@ open class JetpackItem(
         return super.supportsEnchantment(stack, enchantment) && Configs.SERVER.isAllowed(enchantment)
     }
 
-    override fun createParticles(): ParticleOptions {
-        return if (Configs.CLIENT.spawnSnowParticles)
+    override fun createParticles(): ParticleOptions =
+        if (FMLEnvironment.dist.isClient && Configs.CLIENT.spawnSnowParticles) {
             ParticleTypes.SNOWFLAKE
-        else
+        } else {
             AirParticleData(0F, 0.01F)
-    }
+        }
 
     class Layered(
         properties: Properties,


### PR DESCRIPTION
Fixes #191.

## Summary

This PR fixes an instant crash when joining a NeoForge 1.21.1 dedicated server with Create Jetpack, where the player was kicked on join due to an `IllegalStateException` when reading the client config.

## Changes

- **JetpackItem.kt**
  - Update `createParticles()` to:
    - Only read `Configs.CLIENT.spawnSnowParticles` on the **client** (`FMLEnvironment.dist.isClient`).
    - Use `AirParticleData` on the server side so the server no longer touches the client config when spawning jetpack particles.

- **ClientConfig.kt**
  - Make `spawnSnowParticles` more robust by wrapping `SEASONAL_EFFECTS.get()` in `runCatching { ... }.getOrDefault(true)` to avoid an exception if the config is accessed before it has fully loaded.
  - This keeps the previous behaviour (defaulting to `true`) while preventing the crash.

## Rationale

On NeoForge 1.21.1, the config can be queried before it is fully loaded when a player joins a dedicated server.  
Because `createParticles()` indirectly read the client config on the server thread, this resulted in an `IllegalStateException` and the player being kicked on join.

By:
- gating the read with `FMLEnvironment.dist.isClient`, and
- making the config accessor tolerant to early reads,

the join crash no longer happens.

## Testing

Tested on:

- Minecraft 1.21.1
- NeoForge 21.1.x
- Dedicated server with Create Jetpack built from this branch

Steps:

1. Start a NeoForge 1.21.1 dedicated server with the patched Create Jetpack.
2. Join the server with a player that has a jetpack.
3. Confirm that the player is no longer kicked on join.
4. Fly with the jetpack on the client and verify that particles still behave as expected.

No crashes occurred during these tests.
