### PR TITLE
Fabric: jetpacks no longer have/consume durability

### DIFF
--- a/src/main/kotlin/com/possible_triangle/create_jetpack/Content.kt
+++ b/src/main/kotlin/com/possible_triangle/create_jetpack/Content.kt
@@ -77,6 +77,7 @@ object Content {
             )
         }
         .properties { it.rarity(Rarity.RARE) }
+        .properties { it.durability(-1) }
         .jetpackProperties()
         .register()
 
@@ -108,6 +109,7 @@ object Content {
         }
         .properties { it.rarity(Rarity.EPIC) }
         .properties { it.fireResistant() }
+        .properties { it.durability(-1) }
         .jetpackProperties()
         .register()
 


### PR DESCRIPTION
- Added missing property needed on Fabric for the jetpacks not to have durability

Resolves #211